### PR TITLE
Wrapped calls to $().trigger in Ember.run

### DIFF
--- a/tests/integration/components/my-input-test.js
+++ b/tests/integration/components/my-input-test.js
@@ -1,4 +1,5 @@
 /* jshint expr:true */
+import Ember from 'ember';
 import { expect } from 'chai';
 import {
   describeComponent,
@@ -18,10 +19,10 @@ describeComponent(
       this.render(hbs`{{my-input}}`);
       expect(this.$('input').val()).to.equal('init');
 
-      this.$('input').trigger('focusin');
+      Ember.run(this.$('input'), 'trigger', 'focusin');
       expect(this.$('input').val()).to.equal('focusin');
 
-      this.$('input').trigger('focusout');
+      Ember.run(this.$('input'), 'trigger', 'focusout');
       expect(this.$('input').val()).to.equal('focusout');
     });
   }


### PR DESCRIPTION
It is still fishy that the exact same tests pass in QUnit but not Mocha, but at least this makes the tests work in Mocha.